### PR TITLE
Fix: Resolve IndexError in crosstab_means for inconsistent nominal ca…

### DIFF
--- a/DeliberativePolling/__init__.py
+++ b/DeliberativePolling/__init__.py
@@ -732,9 +732,11 @@ def crosstab_concat(crosstab1, crosstab2):
 
 
 def crosstab_means(sample, nominal_variable, ordinal_variable):
-    sample.means = pd.DataFrame(
-        [[pd.NA] * len(sample.crosstab.columns)], columns=sample.crosstab.columns
-    )
+    # Get all unique categories across both samples
+    all_categories = sample.one.crosstab.columns.union(sample.two.crosstab.columns)
+
+    # Initialize sample.means with enough columns for all categories
+    sample.means = pd.DataFrame([[pd.NA] * len(all_categories)], columns=all_categories)
 
     for filter in sample.one.crosstab.columns:
         mean1, mean2, mean_difference = t_test(


### PR DESCRIPTION
This commit addresses an IndexError that occurred in the crosstab_means function when comparing samples with nominal variables having inconsistent categories across time periods or groups.

The error IndexError: iloc cannot enlarge its target object arose because the sample.means DataFrame was not initialized with enough columns to accommodate all possible categories of the nominal variable. This happened when a category was present in one sample but absent in the other.

The fix replaces the original initialization of sample.means with a new approach that determines all unique categories across both samples using sample.one.crosstab.columns.union(sample.two.crosstab.columns). This ensures that sample.means is always created with the correct number of columns, preventing the IndexError and allowing for proper handling of nominal variables with varying categories.